### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/python/google/protobuf/internal/generator_test.py
+++ b/python/google/protobuf/internal/generator_test.py
@@ -119,10 +119,9 @@ class GeneratorTest(unittest.TestCase):
         'default_int32': True,
     }
 
-    has_default_by_name = dict(
-        [(f.name, f.has_default_value)
+    has_default_by_name = {f.name: f.has_default_value
          for f in desc.fields
-         if f.name in expected_has_default_by_name])
+         if f.name in expected_has_default_by_name}
     self.assertEqual(expected_has_default_by_name, has_default_by_name)
 
   def testContainingTypeBehaviorForExtensions(self):

--- a/python/mox.py
+++ b/python/mox.py
@@ -1029,8 +1029,8 @@ class SameElementsAs(Comparator):
     """
 
     try:
-      expected = dict([(element, None) for element in self._expected_seq])
-      actual = dict([(element, None) for element in actual_seq])
+      expected = {element: None for element in self._expected_seq}
+      actual = {element: None for element in actual_seq}
     except TypeError:
       # Fall back to slower list-compare if any of the objects are unhashable.
       expected = list(self._expected_seq)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:protobuf?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:protobuf?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
