### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/conformance/conformance_python.py
+++ b/conformance/conformance_python.py
@@ -114,7 +114,7 @@ def do_test_io():
   sys.stdout.flush()
 
   if verbose:
-    sys.stderr.write("conformance_python: request=%s, response=%s\n" % (
+    sys.stderr.write("conformance_python: request={0!s}, response={1!s}\n".format(
                        request.ShortDebugString().c_str(),
                        response.ShortDebugString().c_str()))
 
@@ -126,5 +126,5 @@ def do_test_io():
 while True:
   if not do_test_io():
     sys.stderr.write("conformance_python: received EOF from test runner " +
-                     "after %s tests, exiting\n" % (test_count))
+                     "after {0!s} tests, exiting\n".format((test_count)))
     sys.exit(0)

--- a/objectivec/DevTools/pddm_tests.py
+++ b/objectivec/DevTools/pddm_tests.py
@@ -119,10 +119,10 @@ body2""")
       f = io.StringIO(input_str)
       try:
         result = pddm.MacroCollection(f)
-        self.fail('Should throw exception, entry %d' % idx)
+        self.fail('Should throw exception, entry {0:d}'.format(idx))
       except pddm.PDDMError as e:
         self.assertTrue(e.message.startswith(expected_prefix),
-                        'Entry %d failed: %r' % (idx, e))
+                        'Entry {0:d} failed: {1!r}'.format(idx, e))
 
   def testParseBeginIssues(self):
     test_list = [
@@ -174,10 +174,10 @@ body2""")
       f = io.StringIO(input_str)
       try:
         result = pddm.MacroCollection(f)
-        self.fail('Should throw exception, entry %d' % idx)
+        self.fail('Should throw exception, entry {0:d}'.format(idx))
       except pddm.PDDMError as e:
         self.assertTrue(e.message.startswith(expected_prefix),
-                        'Entry %d failed: %r' % (idx, e))
+                        'Entry {0:d} failed: {1!r}'.format(idx, e))
 
 
 class TestExpandingMacros(unittest.TestCase):
@@ -223,8 +223,7 @@ PDDM-DEFINE-END
     for idx, (input_str, expected) in enumerate(test_list, 1):
       result = mc.Expand(input_str)
       self.assertEqual(result, expected,
-                       'Entry %d --\n       Result: %r\n     Expected: %r' %
-                       (idx, result, expected))
+                       'Entry {0:d} --\n       Result: {1!r}\n     Expected: {2!r}'.format(idx, result, expected))
 
   def testExpandArgOptions(self):
     f = io.StringIO(u"""
@@ -267,10 +266,10 @@ a - a$z
     for idx, (input_str, expected_err) in enumerate(test_list, 1):
       try:
         result = mc.Expand(input_str)
-        self.fail('Should throw exception, entry %d' % idx)
+        self.fail('Should throw exception, entry {0:d}'.format(idx))
       except pddm.PDDMError as e:
         self.assertEqual(e.message, expected_err,
-                        'Entry %d failed: %r' % (idx, e))
+                        'Entry {0:d} failed: {1!r}'.format(idx, e))
 
   def testExpandReferences(self):
     f = io.StringIO(u"""
@@ -311,7 +310,7 @@ foo(x, y)
     mc = pddm.MacroCollection(f)
     try:
       result = mc.Expand('foo(A,B)')
-      self.fail('Should throw exception, entry %d' % idx)
+      self.fail('Should throw exception, entry {0:d}'.format(idx))
     except pddm.PDDMError as e:
       self.assertEqual(e.message,
                        'Found macro recusion, invoking "foo(1, A)":\n...while expanding "bar(1, A)".\n...while expanding "foo(A,B)".')
@@ -352,12 +351,10 @@ class TestParsingSource(unittest.TestCase):
       sf = pddm.SourceFile(f)
       sf._ParseFile()
       self.assertEqual(len(sf._sections), len(line_counts),
-                       'Entry %d -- %d != %d' %
-                       (idx, len(sf._sections), len(line_counts)))
+                       'Entry {0:d} -- {1:d} != {2:d}'.format(idx, len(sf._sections), len(line_counts)))
       for idx2, (sec, expected) in enumerate(zip(sf._sections, line_counts), 1):
         self.assertEqual(sec.num_lines_captured, expected,
-                         'Entry %d, section %d -- %d != %d' %
-                         (idx, idx2, sec.num_lines_captured, expected))
+                         'Entry {0:d}, section {1:d} -- {2:d} != {3:d}'.format(idx, idx2, sec.num_lines_captured, expected))
 
   def testErrors(self):
     test_list = [
@@ -386,10 +383,10 @@ class TestParsingSource(unittest.TestCase):
       f = io.StringIO(input_str)
       try:
         pddm.SourceFile(f)._ParseFile()
-        self.fail('Should throw exception, entry %d' % idx)
+        self.fail('Should throw exception, entry {0:d}'.format(idx))
       except pddm.PDDMError as e:
         self.assertEqual(e.message, expected_err,
-                        'Entry %d failed: %r' % (idx, e))
+                        'Entry {0:d} failed: {1!r}'.format(idx, e))
 
 class TestProcessingSource(unittest.TestCase):
 
@@ -483,7 +480,7 @@ foo
     sf = pddm.SourceFile(f)
     try:
       sf.ProcessContent()
-      self.fail('Should throw exception, entry %d' % idx)
+      self.fail('Should throw exception, entry {0:d}'.format(idx))
     except pddm.PDDMError as e:
       self.assertEqual(e.message,
                        'Attempt to redefine macro: "PDDM-DEFINE mumble(x_)"\n'
@@ -503,7 +500,7 @@ foo
     sf = pddm.SourceFile(f)
     try:
       sf.ProcessContent()
-      self.fail('Should throw exception, entry %d' % idx)
+      self.fail('Should throw exception, entry {0:d}'.format(idx))
     except pddm.PDDMError as e:
       self.assertEqual(e.message,
                        'No macro named "foobar".\n'

--- a/python/google/protobuf/descriptor.py
+++ b/python/google/protobuf/descriptor.py
@@ -127,8 +127,8 @@ class DescriptorBase(six.with_metaclass(DescriptorMetaclass)):
     try:
       options_class = getattr(descriptor_pb2, self._options_class_name)
     except AttributeError:
-      raise RuntimeError('Unknown options class name %s!' %
-                         (self._options_class_name))
+      raise RuntimeError('Unknown options class name {0!s}!'.format(
+                         (self._options_class_name)))
     self._options = options_class()
     return self._options
 
@@ -564,7 +564,7 @@ class FieldDescriptor(DescriptorBase):
     try:
       return FieldDescriptor._PYTHON_TO_CPP_PROTO_TYPE_MAP[proto_type]
     except KeyError:
-      raise TypeTransformationError('Unknown proto_type: %s' % proto_type)
+      raise TypeTransformationError('Unknown proto_type: {0!s}'.format(proto_type))
 
 
 class EnumDescriptor(_NestedDescriptorBase):

--- a/python/google/protobuf/descriptor_database.py
+++ b/python/google/protobuf/descriptor_database.py
@@ -63,7 +63,7 @@ class DescriptorDatabase(object):
       self._file_desc_protos_by_file[proto_name] = file_desc_proto
     elif self._file_desc_protos_by_file[proto_name] != file_desc_proto:
       raise DescriptorDatabaseConflictingDefinitionError(
-          '%s already added, but with different descriptor.' % proto_name)
+          '{0!s} already added, but with different descriptor.'.format(proto_name))
 
     # Add the top-level Message, Enum and Extension descriptors to the index.
     package = file_desc_proto.package

--- a/python/google/protobuf/descriptor_pool.py
+++ b/python/google/protobuf/descriptor_pool.py
@@ -202,7 +202,7 @@ class DescriptorPool(object):
       else:
         raise error
     if not file_proto:
-      raise KeyError('Cannot find a file named %s' % file_name)
+      raise KeyError('Cannot find a file named {0!s}'.format(file_name))
     return self._ConvertFileProtoToFileDescriptor(file_proto)
 
   def FindFileContainingSymbol(self, symbol):
@@ -237,7 +237,7 @@ class DescriptorPool(object):
       else:
         raise error
     if not file_proto:
-      raise KeyError('Cannot find a file containing %s' % symbol)
+      raise KeyError('Cannot find a file containing {0!s}'.format(symbol))
     return self._ConvertFileProtoToFileDescriptor(file_proto)
 
   def FindMessageTypeByName(self, full_name):
@@ -511,7 +511,7 @@ class DescriptorPool(object):
                                      values=values,
                                      containing_type=containing_type,
                                      options=enum_proto.options)
-    scope['.%s' % enum_name] = desc
+    scope['.{0!s}'.format(enum_name)] = desc
     self._enum_descriptors[enum_name] = desc
     return desc
 
@@ -733,7 +733,7 @@ class DescriptorPool(object):
 
 
 def _PrefixWithDot(name):
-  return name if name.startswith('.') else '.%s' % name
+  return name if name.startswith('.') else '.{0!s}'.format(name)
 
 
 if _USE_C_DESCRIPTORS:

--- a/python/google/protobuf/internal/_parameterized.py
+++ b/python/google/protobuf/internal/_parameterized.py
@@ -170,7 +170,7 @@ def _CleanRepr(obj):
 # Helper function formerly from the unittest module, removed from it in
 # Python 2.7.
 def _StrClass(cls):
-  return '%s.%s' % (cls.__module__, cls.__name__)
+  return '{0!s}.{1!s}'.format(cls.__module__, cls.__name__)
 
 
 def _NonStringIterable(obj):
@@ -180,7 +180,7 @@ def _NonStringIterable(obj):
 
 def _FormatParameterList(testcase_params):
   if isinstance(testcase_params, collections.Mapping):
-    return ', '.join('%s=%s' % (argname, _CleanRepr(value))
+    return ', '.join('{0!s}={1!s}'.format(argname, _CleanRepr(value))
                      for argname, value in testcase_params.items())
   elif _NonStringIterable(testcase_params):
     return ', '.join(map(_CleanRepr, testcase_params))
@@ -240,15 +240,15 @@ class _ParameterizedTestIter(object):
         # method of TestGeneratorMetaclass.
         # The metaclass will make sure to create a unique, but nondescriptive
         # name for this test.
-        BoundParamTest.__x_extra_id__ = '(%s)' % (
-            _FormatParameterList(testcase_params),)
+        BoundParamTest.__x_extra_id__ = '({0!s})'.format(
+            _FormatParameterList(testcase_params))
       else:
-        raise RuntimeError('%s is not a valid naming type.' % (naming_type,))
+        raise RuntimeError('{0!s} is not a valid naming type.'.format(naming_type))
 
-      BoundParamTest.__doc__ = '%s(%s)' % (
+      BoundParamTest.__doc__ = '{0!s}({1!s})'.format(
           BoundParamTest.__name__, _FormatParameterList(testcase_params))
       if test_method.__doc__:
-        BoundParamTest.__doc__ += '\n%s' % (test_method.__doc__,)
+        BoundParamTest.__doc__ += '\n{0!s}'.format(test_method.__doc__)
       return BoundParamTest
     return (MakeBoundParamTest(c) for c in self.testcases)
 
@@ -373,14 +373,14 @@ def _UpdateClassDictForParamTestCase(dct, id_suffix, name, iterator):
     iterator: The iterator generating the individual test cases.
   """
   for idx, func in enumerate(iterator):
-    assert callable(func), 'Test generators must yield callables, got %r' % (
-        func,)
+    assert callable(func), 'Test generators must yield callables, got {0!r}'.format(
+        func)
     if getattr(func, '__x_use_name__', False):
       new_name = func.__name__
     else:
-      new_name = '%s%s%d' % (name, _SEPARATOR, idx)
+      new_name = '{0!s}{1!s}{2:d}'.format(name, _SEPARATOR, idx)
     assert new_name not in dct, (
-        'Name of parameterized test case "%s" not unique' % (new_name,))
+        'Name of parameterized test case "{0!s}" not unique'.format(new_name))
     dct[new_name] = func
     id_suffix[new_name] = getattr(func, '__x_extra_id__', '')
 
@@ -393,7 +393,7 @@ class ParameterizedTestCase(unittest.TestCase):
     return self._testMethodName.split(_SEPARATOR)[0]
 
   def __str__(self):
-    return '%s (%s)' % (self._OriginalName(), _StrClass(self.__class__))
+    return '{0!s} ({1!s})'.format(self._OriginalName(), _StrClass(self.__class__))
 
   def id(self):  # pylint: disable=invalid-name
     """Returns the descriptive ID of the test.
@@ -404,7 +404,7 @@ class ParameterizedTestCase(unittest.TestCase):
     Returns:
       The test id.
     """
-    return '%s.%s%s' % (_StrClass(self.__class__),
+    return '{0!s}.{1!s}{2!s}'.format(_StrClass(self.__class__),
                         self._OriginalName(),
                         self._id_suffix.get(self._testMethodName, ''))
 

--- a/python/google/protobuf/internal/decoder.py
+++ b/python/google/protobuf/internal/decoder.py
@@ -469,7 +469,7 @@ def StringDecoder(field_number, is_repeated, is_packed, key, new_default):
       return local_unicode(byte_str, 'utf-8')
     except UnicodeDecodeError as e:
       # add more information to the error message and re-raise it.
-      e.reason = '%s in field: %s' % (e, key.full_name)
+      e.reason = '{0!s} in field: {1!s}'.format(e, key.full_name)
       raise
 
   assert not is_packed

--- a/python/google/protobuf/internal/descriptor_test.py
+++ b/python/google/protobuf/internal/descriptor_test.py
@@ -529,8 +529,7 @@ class DescriptorCopyToProtoTest(unittest.TestCase):
 
     self.assertEqual(
         actual_proto, expected_proto,
-        'Not equal,\nActual:\n%s\nExpected:\n%s\n'
-        % (str(actual_proto), str(expected_proto)))
+        'Not equal,\nActual:\n{0!s}\nExpected:\n{1!s}\n'.format(str(actual_proto), str(expected_proto)))
 
   def _InternalTestCopyToProto(self, desc, expected_proto_class,
                                expected_proto_ascii):

--- a/python/google/protobuf/internal/enum_type_wrapper.py
+++ b/python/google/protobuf/internal/enum_type_wrapper.py
@@ -52,14 +52,14 @@ class EnumTypeWrapper(object):
     """Returns a string containing the name of an enum value."""
     if number in self._enum_type.values_by_number:
       return self._enum_type.values_by_number[number].name
-    raise ValueError('Enum %s has no name defined for value %d' % (
+    raise ValueError('Enum {0!s} has no name defined for value {1:d}'.format(
         self._enum_type.name, number))
 
   def Value(self, name):
     """Returns the value coresponding to the given enum name."""
     if name in self._enum_type.values_by_name:
       return self._enum_type.values_by_name[name].number
-    raise ValueError('Enum %s has no value defined for name %s' % (
+    raise ValueError('Enum {0!s} has no value defined for name {1!s}'.format(
         self._enum_type.name, name))
 
   def keys(self):

--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -1680,7 +1680,7 @@ class Proto3Test(unittest.TestCase):
     # Packs to Any.
     msg.value.Pack(all_types)
     self.assertEqual(msg.value.type_url,
-                     'type.googleapis.com/%s' % all_descriptor.full_name)
+                     'type.googleapis.com/{0!s}'.format(all_descriptor.full_name))
     self.assertEqual(msg.value.value,
                      all_types.SerializeToString())
     # Tests Is() method.
@@ -1698,8 +1698,8 @@ class Proto3Test(unittest.TestCase):
     except AttributeError:
       pass
     else:
-      raise AttributeError('%s should not have Pack method.' %
-                           msg_descriptor.full_name)
+      raise AttributeError('{0!s} should not have Pack method.'.format(
+                           msg_descriptor.full_name))
 
 
 
@@ -1708,10 +1708,10 @@ class ValidTypeNamesTest(unittest.TestCase):
   def assertImportFromName(self, msg, base_name):
     # Parse <type 'module.class_name'> to extra 'some.name' as a string.
     tp_name = str(type(msg)).split("'")[1]
-    valid_names = ('Repeated%sContainer' % base_name,
-                   'Repeated%sFieldContainer' % base_name)
+    valid_names = ('Repeated{0!s}Container'.format(base_name),
+                   'Repeated{0!s}FieldContainer'.format(base_name))
     self.assertTrue(any(tp_name.endswith(v) for v in valid_names),
-                    '%r does end with any of %r' % (tp_name, valid_names))
+                    '{0!r} does end with any of {1!r}'.format(tp_name, valid_names))
 
     parts = tp_name.split('.')
     class_name = parts[-1]

--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -223,15 +223,14 @@ def _VerifyExtensionHandle(message, extension_handle):
   """Verify that the given extension handle is valid."""
 
   if not isinstance(extension_handle, _FieldDescriptor):
-    raise KeyError('HasExtension() expects an extension handle, got: %s' %
-                   extension_handle)
+    raise KeyError('HasExtension() expects an extension handle, got: {0!s}'.format(
+                   extension_handle))
 
   if not extension_handle.is_extension:
-    raise KeyError('"%s" is not an extension.' % extension_handle.full_name)
+    raise KeyError('"{0!s}" is not an extension.'.format(extension_handle.full_name))
 
   if not extension_handle.containing_type:
-    raise KeyError('"%s" is missing a containing_type.'
-                   % extension_handle.full_name)
+    raise KeyError('"{0!s}" is missing a containing_type.'.format(extension_handle.full_name))
 
   if extension_handle.containing_type is not message.DESCRIPTOR:
     raise KeyError('Extension "%s" extends message type "%s", but this '
@@ -369,8 +368,8 @@ def _AddEnumValues(descriptor, cls):
 
 def _GetInitializeDefaultForMap(field):
   if field.label != _FieldDescriptor.LABEL_REPEATED:
-    raise ValueError('map_entry set on non-repeated field %s' % (
-        field.name))
+    raise ValueError('map_entry set on non-repeated field {0!s}'.format((
+        field.name)))
   fields_by_name = field.message_type.fields_by_name
   key_checker = type_checkers.GetTypeChecker(fields_by_name['key'])
 
@@ -406,8 +405,8 @@ def _DefaultValueConstructorForField(field):
 
   if field.label == _FieldDescriptor.LABEL_REPEATED:
     if field.has_default_value and field.default_value != []:
-      raise ValueError('Repeated field default value not empty list: %s' % (
-          field.default_value))
+      raise ValueError('Repeated field default value not empty list: {0!s}'.format((
+          field.default_value)))
     if field.cpp_type == _FieldDescriptor.CPPTYPE_MESSAGE:
       # We can't look at _concrete_class yet since it might not have
       # been set.  (Depends on order in which we initialize the classes).
@@ -447,7 +446,7 @@ def _ReraiseTypeErrorWithFieldName(message_name, field_name):
   exc = sys.exc_info()[1]
   if len(exc.args) == 1 and type(exc) is TypeError:
     # simple TypeError; add field name to exception message
-    exc = TypeError('%s for field %s.%s' % (str(exc), message_name, field_name))
+    exc = TypeError('{0!s} for field {1!s}.{2!s}'.format(str(exc), message_name, field_name))
 
   # re-raise possibly-amended exception with original traceback:
   six.reraise(type(exc), exc, sys.exc_info()[2])
@@ -467,7 +466,7 @@ def _AddInitMethod(message_descriptor, cls):
       try:
         return enum_type.values_by_name[value].number
       except KeyError:
-        raise ValueError('Enum type %s: unknown label "%s"' % (
+        raise ValueError('Enum type {0!s}: unknown label "{1!s}"'.format(
             enum_type.full_name, value))
     return value
 
@@ -488,8 +487,7 @@ def _AddInitMethod(message_descriptor, cls):
     for field_name, field_value in kwargs.items():
       field = _GetFieldByName(message_descriptor, field_name)
       if field is None:
-        raise TypeError("%s() got an unexpected keyword argument '%s'" %
-                        (message_descriptor.name, field_name))
+        raise TypeError("{0!s}() got an unexpected keyword argument '{1!s}'".format(message_descriptor.name, field_name))
       if field.label == _FieldDescriptor.LABEL_REPEATED:
         copy = field._default_constructor(self)
         if field.cpp_type == _FieldDescriptor.CPPTYPE_MESSAGE:  # Composite
@@ -546,8 +544,7 @@ def _GetFieldByName(message_descriptor, field_name):
   try:
     return message_descriptor.fields_by_name[field_name]
   except KeyError:
-    raise ValueError('Protocol message %s has no "%s" field.' %
-                     (message_descriptor.name, field_name))
+    raise ValueError('Protocol message {0!s} has no "{1!s}" field.'.format(message_descriptor.name, field_name))
 
 
 def _AddPropertiesForFields(descriptor, cls):
@@ -618,7 +615,7 @@ def _AddPropertiesForRepeatedField(field, cls):
       field_value = self._fields.setdefault(field, field_value)
     return field_value
   getter.__module__ = None
-  getter.__doc__ = 'Getter for %s.' % proto_field_name
+  getter.__doc__ = 'Getter for {0!s}.'.format(proto_field_name)
 
   # We define a setter just so we can throw an exception with a more
   # helpful error message.
@@ -626,7 +623,7 @@ def _AddPropertiesForRepeatedField(field, cls):
     raise AttributeError('Assignment not allowed to repeated field '
                          '"%s" in protocol message object.' % proto_field_name)
 
-  doc = 'Magic attribute generated for "%s" proto field.' % proto_field_name
+  doc = 'Magic attribute generated for "{0!s}" proto field.'.format(proto_field_name)
   setattr(cls, property_name, property(getter, setter, doc=doc))
 
 
@@ -653,7 +650,7 @@ def _AddPropertiesForNonRepeatedScalarField(field, cls):
     # default_value.  Combine with has_default_value somehow.
     return self._fields.get(field, default_value)
   getter.__module__ = None
-  getter.__doc__ = 'Getter for %s.' % proto_field_name
+  getter.__doc__ = 'Getter for {0!s}.'.format(proto_field_name)
 
   clear_when_set_to_default = is_proto3 and not field.containing_oneof
 
@@ -679,10 +676,10 @@ def _AddPropertiesForNonRepeatedScalarField(field, cls):
     setter = field_setter
 
   setter.__module__ = None
-  setter.__doc__ = 'Setter for %s.' % proto_field_name
+  setter.__doc__ = 'Setter for {0!s}.'.format(proto_field_name)
 
   # Add a property to encapsulate the getter/setter.
-  doc = 'Magic attribute generated for "%s" proto field.' % proto_field_name
+  doc = 'Magic attribute generated for "{0!s}" proto field.'.format(proto_field_name)
   setattr(cls, property_name, property(getter, setter, doc=doc))
 
 
@@ -717,7 +714,7 @@ def _AddPropertiesForNonRepeatedCompositeField(field, cls):
       field_value = self._fields.setdefault(field, field_value)
     return field_value
   getter.__module__ = None
-  getter.__doc__ = 'Getter for %s.' % proto_field_name
+  getter.__doc__ = 'Getter for {0!s}.'.format(proto_field_name)
 
   # We define a setter just so we can throw an exception with a more
   # helpful error message.
@@ -726,7 +723,7 @@ def _AddPropertiesForNonRepeatedCompositeField(field, cls):
                          '"%s" in protocol message object.' % proto_field_name)
 
   # Add a property to encapsulate the getter.
-  doc = 'Magic attribute generated for "%s" proto field.' % proto_field_name
+  doc = 'Magic attribute generated for "{0!s}" proto field.'.format(proto_field_name)
   setattr(cls, property_name, property(getter, setter, doc=doc))
 
 
@@ -852,8 +849,7 @@ def _AddClearFieldMethod(message_descriptor, cls):
         else:
           return
       except KeyError:
-        raise ValueError('Protocol message %s() has no "%s" field.' %
-                         (message_descriptor.name, field_name))
+        raise ValueError('Protocol message {0!s}() has no "{1!s}" field.'.format(message_descriptor.name, field_name))
 
     if field in self._fields:
       # To match the C++ implementation, we need to invalidate iterators
@@ -905,7 +901,7 @@ def _AddHasExtensionMethod(cls):
   def HasExtension(self, extension_handle):
     _VerifyExtensionHandle(self, extension_handle)
     if extension_handle.label == _FieldDescriptor.LABEL_REPEATED:
-      raise KeyError('"%s" is repeated.' % extension_handle.full_name)
+      raise KeyError('"{0!s}" is repeated.'.format(extension_handle.full_name))
 
     if extension_handle.cpp_type == _FieldDescriptor.CPPTYPE_MESSAGE:
       value = self._fields.get(extension_handle)
@@ -1026,7 +1022,7 @@ def _BytesForNonRepeatedElement(value, field_number, field_type):
     fn = type_checkers.TYPE_TO_BYTE_SIZE_FN[field_type]
     return fn(field_number, value)
   except KeyError:
-    raise message_mod.EncodeError('Unrecognized field type: %d' % field_type)
+    raise message_mod.EncodeError('Unrecognized field type: {0:d}'.format(field_type))
 
 
 def _AddByteSizeMethod(message_descriptor, cls):
@@ -1059,7 +1055,7 @@ def _AddSerializeToStringMethod(message_descriptor, cls):
     errors = []
     if not self.IsInitialized():
       raise message_mod.EncodeError(
-          'Message %s is missing required fields: %s' % (
+          'Message {0!s} is missing required fields: {1!s}'.format(
           self.DESCRIPTOR.full_name, ','.join(self.FindInitializationErrors())))
     return self.SerializePartialToString()
   cls.SerializeToString = SerializeToString
@@ -1196,7 +1192,7 @@ def _AddIsInitializedMethod(message_descriptor, cls):
     for field, value in self.ListFields():
       if field.cpp_type == _FieldDescriptor.CPPTYPE_MESSAGE:
         if field.is_extension:
-          name = "(%s)" % field.full_name
+          name = "({0!s})".format(field.full_name)
         else:
           name = field.name
 
@@ -1204,7 +1200,7 @@ def _AddIsInitializedMethod(message_descriptor, cls):
           if _IsMessageMapField(field):
             for key in value:
               element = value[key]
-              prefix = "%s[%s]." % (name, key)
+              prefix = "{0!s}[{1!s}].".format(name, key)
               sub_errors = element.FindInitializationErrors()
               errors += [prefix + error for error in sub_errors]
           else:
@@ -1213,7 +1209,7 @@ def _AddIsInitializedMethod(message_descriptor, cls):
         elif field.label == _FieldDescriptor.LABEL_REPEATED:
           for i in range(len(value)):
             element = value[i]
-            prefix = "%s[%d]." % (name, i)
+            prefix = "{0!s}[{1:d}].".format(name, i)
             sub_errors = element.FindInitializationErrors()
             errors += [prefix + error for error in sub_errors]
         else:
@@ -1277,7 +1273,7 @@ def _AddWhichOneofMethod(message_descriptor, cls):
       field = message_descriptor.oneofs_by_name[oneof_name]
     except KeyError:
       raise ValueError(
-          'Protocol message has no oneof "%s" field.' % oneof_name)
+          'Protocol message has no oneof "{0!s}" field.'.format(oneof_name))
 
     nested_field = self._oneofs.get(field, None)
     if nested_field is not None and self.HasField(nested_field.name):

--- a/python/google/protobuf/internal/reflection_test.py
+++ b/python/google/protobuf/internal/reflection_test.py
@@ -1652,8 +1652,8 @@ class ReflectionTest(unittest.TestCase):
           another_file_name,
           package_name,
           serialized_pb=file_descriptor_proto.SerializeToString())
-      self.assertTrue(hasattr(cm, 'exception'), '%s not raised' %
-                      getattr(cm.expected, '__name__', cm.expected))
+      self.assertTrue(hasattr(cm, 'exception'), '{0!s} not raised'.format(
+                      getattr(cm.expected, '__name__', cm.expected)))
       self.assertIn('test_file_descriptor_errors.proto', str(cm.exception))
       # Error message will say something about this definition being a
       # duplicate, though we don't check the message exactly to avoid a
@@ -2519,7 +2519,7 @@ class SerializationTest(unittest.TestCase):
       self.assertEqual(exception, str(ex))
       return
     else:
-      raise self.failureException('%s not raised' % str(exc_class))
+      raise self.failureException('{0!s} not raised'.format(str(exc_class)))
 
   def testSerializeUninitialized(self):
     proto = unittest_pb2.TestRequired()

--- a/python/google/protobuf/internal/test_util.py
+++ b/python/google/protobuf/internal/test_util.py
@@ -378,7 +378,7 @@ def ExpectAllFieldsAndExtensionsInOrder(serialized):
   expected = b''.join(expected_strings)
 
   if expected != serialized:
-    raise ValueError('Expected %r, found %r' % (expected, serialized))
+    raise ValueError('Expected {0!r}, found {1!r}'.format(expected, serialized))
 
 
 def ExpectAllFieldsSet(test_case, message):

--- a/python/google/protobuf/internal/text_format_test.py
+++ b/python/google/protobuf/internal/text_format_test.py
@@ -200,7 +200,7 @@ class TextFormatTest(TextFormatBase):
     r = text_format.Parse(wire_text, parsed_message)
     self.assertIs(r, parsed_message)
     self.assertEqual(message, parsed_message,
-                      '\n%s != %s' % (message, parsed_message))
+                      '\n{0!s} != {1!s}'.format(message, parsed_message))
 
   def testPrintRawUtf8String(self, message_module):
     message = message_module.TestAllTypes()
@@ -210,7 +210,7 @@ class TextFormatTest(TextFormatBase):
     parsed_message = message_module.TestAllTypes()
     text_format.Parse(text, parsed_message)
     self.assertEqual(message, parsed_message,
-                      '\n%s != %s' % (message, parsed_message))
+                      '\n{0!s} != {1!s}'.format(message, parsed_message))
 
   def testPrintFloatFormat(self, message_module):
     # Check that float_format argument is passed to sub-message formatting.
@@ -986,7 +986,7 @@ class TokenizerTest(unittest.TestCase):
     # as the '0' special cases.
     int64_max = (1 << 63) - 1
     uint32_max = (1 << 32) - 1
-    text = '-1 %d %d' % (uint32_max + 1, int64_max + 1)
+    text = '-1 {0:d} {1:d}'.format(uint32_max + 1, int64_max + 1)
     tokenizer = text_format._Tokenizer(text.splitlines())
     self.assertRaises(text_format.ParseError, tokenizer.ConsumeUint32)
     self.assertRaises(text_format.ParseError, tokenizer.ConsumeUint64)

--- a/python/google/protobuf/internal/type_checkers.py
+++ b/python/google/protobuf/internal/type_checkers.py
@@ -103,8 +103,7 @@ class TypeChecker(object):
     The returned value might have been normalized to another type.
     """
     if not isinstance(proposed_value, self._acceptable_types):
-      message = ('%.1024r has type %s, but expected one of: %s' %
-                 (proposed_value, type(proposed_value), self._acceptable_types))
+      message = ('{0:.1024!r} has type {1!s}, but expected one of: {2!s}'.format(proposed_value, type(proposed_value), self._acceptable_types))
       raise TypeError(message)
     return proposed_value
 
@@ -117,11 +116,10 @@ class IntValueChecker(object):
 
   def CheckValue(self, proposed_value):
     if not isinstance(proposed_value, six.integer_types):
-      message = ('%.1024r has type %s, but expected one of: %s' %
-                 (proposed_value, type(proposed_value), six.integer_types))
+      message = ('{0:.1024!r} has type {1!s}, but expected one of: {2!s}'.format(proposed_value, type(proposed_value), six.integer_types))
       raise TypeError(message)
     if not self._MIN <= proposed_value <= self._MAX:
-      raise ValueError('Value out of range: %d' % proposed_value)
+      raise ValueError('Value out of range: {0:d}'.format(proposed_value))
     # We force 32-bit values to int and 64-bit values to long to make
     # alternate implementations where the distinction is more significant
     # (e.g. the C++ implementation) simpler.
@@ -141,11 +139,10 @@ class EnumValueChecker(object):
 
   def CheckValue(self, proposed_value):
     if not isinstance(proposed_value, six.integer_types):
-      message = ('%.1024r has type %s, but expected one of: %s' %
-                 (proposed_value, type(proposed_value), six.integer_types))
+      message = ('{0:.1024!r} has type {1!s}, but expected one of: {2!s}'.format(proposed_value, type(proposed_value), six.integer_types))
       raise TypeError(message)
     if proposed_value not in self._enum_type.values_by_number:
-      raise ValueError('Unknown enum value: %d' % proposed_value)
+      raise ValueError('Unknown enum value: {0:d}'.format(proposed_value))
     return proposed_value
 
   def DefaultValue(self):
@@ -161,8 +158,7 @@ class UnicodeValueChecker(object):
 
   def CheckValue(self, proposed_value):
     if not isinstance(proposed_value, (bytes, six.text_type)):
-      message = ('%.1024r has type %s, but expected one of: %s' %
-                 (proposed_value, type(proposed_value), (bytes, six.text_type)))
+      message = ('{0:.1024!r} has type {1!s}, but expected one of: {2!s}'.format(proposed_value, type(proposed_value), (bytes, six.text_type)))
       raise TypeError(message)
 
     # If the value is of type 'bytes' make sure that it is valid UTF-8 data.

--- a/python/google/protobuf/internal/well_known_types.py
+++ b/python/google/protobuf/internal/well_known_types.py
@@ -69,9 +69,9 @@ class Any(object):
   def Pack(self, msg, type_url_prefix='type.googleapis.com/'):
     """Packs the specified message into current Any message."""
     if len(type_url_prefix) < 1 or type_url_prefix[-1] != '/':
-      self.type_url = '%s/%s' % (type_url_prefix, msg.DESCRIPTOR.full_name)
+      self.type_url = '{0!s}/{1!s}'.format(type_url_prefix, msg.DESCRIPTOR.full_name)
     else:
-      self.type_url = '%s%s' % (type_url_prefix, msg.DESCRIPTOR.full_name)
+      self.type_url = '{0!s}{1!s}'.format(type_url_prefix, msg.DESCRIPTOR.full_name)
     self.value = msg.SerializeToString()
 
   def Unpack(self, msg):
@@ -112,12 +112,12 @@ class Timestamp(object):
       return result + 'Z'
     if (nanos % 1e6) == 0:
       # Serialize 3 fractional digits.
-      return result + '.%03dZ' % (nanos / 1e6)
+      return result + '.{0:03d}Z'.format((nanos / 1e6))
     if (nanos % 1e3) == 0:
       # Serialize 6 fractional digits.
-      return result + '.%06dZ' % (nanos / 1e3)
+      return result + '.{0:06d}Z'.format((nanos / 1e3))
     # Serialize 9 fractional digits.
-    return result + '.%09dZ' % nanos
+    return result + '.{0:09d}Z'.format(nanos)
 
   def FromJsonString(self, value):
     """Parse a RFC 3339 date string format to Timestamp.
@@ -251,19 +251,19 @@ class Duration(object):
       result = ''
       seconds = self.seconds + int(self.nanos // 1e9)
       nanos = self.nanos % 1e9
-    result += '%d' % seconds
+    result += '{0:d}'.format(seconds)
     if (nanos % 1e9) == 0:
       # If there are 0 fractional digits, the fractional
       # point '.' should be omitted when serializing.
       return result + 's'
     if (nanos % 1e6) == 0:
       # Serialize 3 fractional digits.
-      return result + '.%03ds' % (nanos / 1e6)
+      return result + '.{0:03d}s'.format((nanos / 1e6))
     if (nanos % 1e3) == 0:
       # Serialize 6 fractional digits.
-      return result + '.%06ds' % (nanos / 1e3)
+      return result + '.{0:06d}s'.format((nanos / 1e3))
     # Serialize 9 fractional digits.
-    return result + '.%09ds' % nanos
+    return result + '.{0:09d}s'.format(nanos)
 
   def FromJsonString(self, value):
     """Converts a string to Duration.

--- a/python/google/protobuf/internal/well_known_types_test.py
+++ b/python/google/protobuf/internal/well_known_types_test.py
@@ -589,7 +589,7 @@ class AnyTest(unittest.TestCase):
     # Packs to Any.
     msg.value.Pack(all_types)
     self.assertEqual(msg.value.type_url,
-                     'type.googleapis.com/%s' % all_descriptor.full_name)
+                     'type.googleapis.com/{0!s}'.format(all_descriptor.full_name))
     self.assertEqual(msg.value.value,
                      all_types.SerializeToString())
     # Tests Is() method.
@@ -607,8 +607,8 @@ class AnyTest(unittest.TestCase):
     except AttributeError:
       pass
     else:
-      raise AttributeError('%s should not have Pack method.' %
-                           msg_descriptor.full_name)
+      raise AttributeError('{0!s} should not have Pack method.'.format(
+                           msg_descriptor.full_name))
 
   def testPackWithCustomTypeUrl(self):
     submessage = any_test_pb2.TestAny()
@@ -617,15 +617,15 @@ class AnyTest(unittest.TestCase):
     # Pack with a custom type URL prefix.
     msg.Pack(submessage, 'type.myservice.com')
     self.assertEqual(msg.type_url,
-                     'type.myservice.com/%s' % submessage.DESCRIPTOR.full_name)
+                     'type.myservice.com/{0!s}'.format(submessage.DESCRIPTOR.full_name))
     # Pack with a custom type URL prefix ending with '/'.
     msg.Pack(submessage, 'type.myservice.com/')
     self.assertEqual(msg.type_url,
-                     'type.myservice.com/%s' % submessage.DESCRIPTOR.full_name)
+                     'type.myservice.com/{0!s}'.format(submessage.DESCRIPTOR.full_name))
     # Pack with an empty type URL prefix.
     msg.Pack(submessage, '')
     self.assertEqual(msg.type_url,
-                     '/%s' % submessage.DESCRIPTOR.full_name)
+                     '/{0!s}'.format(submessage.DESCRIPTOR.full_name))
     # Test unpacking the type.
     unpacked_message = any_test_pb2.TestAny()
     self.assertTrue(msg.Unpack(unpacked_message))

--- a/python/google/protobuf/internal/wire_format.py
+++ b/python/google/protobuf/internal/wire_format.py
@@ -86,7 +86,7 @@ def PackTag(field_number, wire_type):
     wire_type: One of the WIRETYPE_* constants.
   """
   if not 0 <= wire_type <= _WIRETYPE_MAX:
-    raise message.EncodeError('Unknown wire type: %d' % wire_type)
+    raise message.EncodeError('Unknown wire type: {0:d}'.format(wire_type))
   return (field_number << TAG_TYPE_BITS) | wire_type
 
 
@@ -244,7 +244,7 @@ def _VarUInt64ByteSizeNoTag(uint64):
   if uint64 <= 0xffffffffffffff: return 8
   if uint64 <= 0x7fffffffffffffff: return 9
   if uint64 > UINT64_MAX:
-    raise message.EncodeError('Value out of range: %d' % uint64)
+    raise message.EncodeError('Value out of range: {0:d}'.format(uint64))
   return 10
 
 

--- a/python/google/protobuf/service_reflection.py
+++ b/python/google/protobuf/service_reflection.py
@@ -223,7 +223,7 @@ class _ServiceBuilder(object):
       rpc_controller: RPC controller used to execute this method.
       callback: A callback which will be invoked when the method finishes.
     """
-    rpc_controller.SetFailed('Method %s not implemented.' % method_name)
+    rpc_controller.SetFailed('Method {0!s} not implemented.'.format(method_name))
     callback(None)
 
 

--- a/python/google/protobuf/text_encoding.py
+++ b/python/google/protobuf/text_encoding.py
@@ -44,9 +44,9 @@ _cescape_utf8_to_str[34] = r'\"'  # necessary escape
 _cescape_utf8_to_str[92] = r'\\'  # necessary escape
 
 # Lookup table for non-utf8, with necessary escapes at (o >= 127 or o < 32)
-_cescape_byte_to_str = ([r'\%03o' % i for i in range(0, 32)] +
+_cescape_byte_to_str = ([r'\{0:03o}'.format(i) for i in range(0, 32)] +
                         [chr(i) for i in range(32, 127)] +
-                        [r'\%03o' % i for i in range(127, 256)])
+                        [r'\{0:03o}'.format(i) for i in range(127, 256)])
 _cescape_byte_to_str[9] = r'\t'  # optional escape
 _cescape_byte_to_str[10] = r'\n'  # optional escape
 _cescape_byte_to_str[13] = r'\r'  # optional escape
@@ -81,7 +81,7 @@ def CEscape(text, as_utf8):
 
 _CUNESCAPE_HEX = re.compile(r'(\\+)x([0-9a-fA-F])(?![0-9a-fA-F])')
 _cescape_highbit_to_str = ([chr(i) for i in range(0, 127)] +
-                           [r'\%03o' % i for i in range(127, 256)])
+                           [r'\{0:03o}'.format(i) for i in range(127, 256)])
 
 
 def CUnescape(text):

--- a/python/google/protobuf/text_format.py
+++ b/python/google/protobuf/text_format.py
@@ -225,14 +225,14 @@ def PrintFieldValue(field, value, out, indent=0, as_utf8=False,
 
   if field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_MESSAGE:
     if as_one_line:
-      out.write(' %s ' % openb)
+      out.write(' {0!s} '.format(openb))
       PrintMessage(value, out, indent, as_utf8, as_one_line,
                    pointy_brackets=pointy_brackets,
                    use_index_order=use_index_order,
                    float_format=float_format)
       out.write(closeb)
     else:
-      out.write(' %s\n' % openb)
+      out.write(' {0!s}\n'.format(openb))
       PrintMessage(value, out, indent + 2, as_utf8, as_one_line,
                    pointy_brackets=pointy_brackets,
                    use_index_order=use_index_order,
@@ -403,8 +403,8 @@ def _MergeField(tokenizer,
 
     if not message_descriptor.is_extendable:
       raise tokenizer.ParseErrorPreviousToken(
-          'Message type "%s" does not have extensions.' %
-          message_descriptor.full_name)
+          'Message type "{0!s}" does not have extensions.'.format(
+          message_descriptor.full_name))
     # pylint: disable=protected-access
     field = message.Extensions._FindExtensionByName(name)
     # pylint: enable=protected-access
@@ -413,10 +413,10 @@ def _MergeField(tokenizer,
         field = None
       else:
         raise tokenizer.ParseErrorPreviousToken(
-            'Extension "%s" not registered.' % name)
+            'Extension "{0!s}" not registered.'.format(name))
     elif message_descriptor != field.containing_type:
       raise tokenizer.ParseErrorPreviousToken(
-          'Extension "%s" does not extend message type "%s".' % (
+          'Extension "{0!s}" does not extend message type "{1!s}".'.format(
               name, message_descriptor.full_name))
 
     tokenizer.Consume(']')
@@ -439,7 +439,7 @@ def _MergeField(tokenizer,
 
     if not field:
       raise tokenizer.ParseErrorPreviousToken(
-          'Message type "%s" has no field named "%s".' % (
+          'Message type "{0!s}" has no field named "{1!s}".'.format(
               message_descriptor.full_name, name))
 
   if field and field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_MESSAGE:
@@ -468,7 +468,7 @@ def _MergeField(tokenizer,
 
     while not tokenizer.TryConsume(end_token):
       if tokenizer.AtEnd():
-        raise tokenizer.ParseErrorPreviousToken('Expected "%s".' % (end_token))
+        raise tokenizer.ParseErrorPreviousToken('Expected "{0!s}".'.format((end_token)))
       _MergeField(tokenizer, sub_message, allow_multiple_scalars,
                   allow_unknown_extension)
 
@@ -628,7 +628,7 @@ def _MergeScalarField(tokenizer, message, field, allow_multiple_scalars):
   elif field.type == descriptor.FieldDescriptor.TYPE_ENUM:
     value = tokenizer.ConsumeEnum(field)
   else:
-    raise RuntimeError('Unknown field type %d' % field.type)
+    raise RuntimeError('Unknown field type {0:d}'.format(field.type))
 
   if field.label == descriptor.FieldDescriptor.LABEL_REPEATED:
     if field.is_extension:
@@ -639,15 +639,13 @@ def _MergeScalarField(tokenizer, message, field, allow_multiple_scalars):
     if field.is_extension:
       if not allow_multiple_scalars and message.HasExtension(field):
         raise tokenizer.ParseErrorPreviousToken(
-            'Message type "%s" should not have multiple "%s" extensions.' %
-            (message.DESCRIPTOR.full_name, field.full_name))
+            'Message type "{0!s}" should not have multiple "{1!s}" extensions.'.format(message.DESCRIPTOR.full_name, field.full_name))
       else:
         message.Extensions[field] = value
     else:
       if not allow_multiple_scalars and message.HasField(field.name):
         raise tokenizer.ParseErrorPreviousToken(
-            'Message type "%s" should not have multiple "%s" fields.' %
-            (message.DESCRIPTOR.full_name, field.name))
+            'Message type "{0!s}" should not have multiple "{1!s}" fields.'.format(message.DESCRIPTOR.full_name, field.name))
       else:
         setattr(message, field.name, value)
 
@@ -741,7 +739,7 @@ class _Tokenizer(object):
       ParseError: If the text couldn't be consumed.
     """
     if not self.TryConsume(token):
-      raise self._ParseError('Expected "%s".' % token)
+      raise self._ParseError('Expected "{0!s}".'.format(token))
 
   def TryConsumeIdentifier(self):
     try:
@@ -932,10 +930,10 @@ class _Tokenizer(object):
     """
     text = self.token
     if len(text) < 1 or text[0] not in _QUOTES:
-      raise self._ParseError('Expected string but found: %r' % (text,))
+      raise self._ParseError('Expected string but found: {0!r}'.format(text))
 
     if len(text) < 2 or text[-1] != text[0]:
-      raise self._ParseError('String missing ending quote: %r' % (text,))
+      raise self._ParseError('String missing ending quote: {0!r}'.format(text))
 
     try:
       result = text_encoding.CUnescape(text[1:-1])
@@ -961,12 +959,12 @@ class _Tokenizer(object):
     Returns:
       A ParseError instance.
     """
-    return ParseError('%d:%d : %s' % (
+    return ParseError('{0:d}:{1:d} : {2!s}'.format(
         self._previous_line + 1, self._previous_column + 1, message))
 
   def _ParseError(self, message):
     """Creates and *returns* a ParseError for the current token."""
-    return ParseError('%d:%d : %s' % (
+    return ParseError('{0:d}:{1:d} : {2!s}'.format(
         self._line + 1, self._column + 1, message))
 
   def _StringParseError(self, e):
@@ -1016,7 +1014,7 @@ def ParseInteger(text, is_signed=False, is_long=False):
     else:
       result = int(text, 0)
   except ValueError:
-    raise ValueError('Couldn\'t parse integer: %s' % text)
+    raise ValueError('Couldn\'t parse integer: {0!s}'.format(text))
 
   # Check if the integer is sane. Exceptions handled by callers.
   checker = _INTEGER_CHECKERS[2 * int(is_long) + int(is_signed)]
@@ -1053,7 +1051,7 @@ def ParseFloat(text):
       try:
         return float(text.rstrip('f'))
       except ValueError:
-        raise ValueError('Couldn\'t parse float: %s' % text)
+        raise ValueError('Couldn\'t parse float: {0!s}'.format(text))
 
 
 def ParseBool(text):
@@ -1100,13 +1098,13 @@ def ParseEnum(field, value):
     enum_value = enum_descriptor.values_by_name.get(value, None)
     if enum_value is None:
       raise ValueError(
-          'Enum type "%s" has no value named %s.' % (
+          'Enum type "{0!s}" has no value named {1!s}.'.format(
               enum_descriptor.full_name, value))
   else:
     # Numeric value.
     enum_value = enum_descriptor.values_by_number.get(number, None)
     if enum_value is None:
       raise ValueError(
-          'Enum type "%s" has no value with number %d.' % (
+          'Enum type "{0!s}" has no value with number {1:d}.'.format(
               enum_descriptor.full_name, number))
   return enum_value.number

--- a/python/mox.py
+++ b/python/mox.py
@@ -94,9 +94,9 @@ class ExpectedMethodCallsError(Error):
     self._expected_methods = expected_methods
 
   def __str__(self):
-    calls = "\n".join(["%3d.  %s" % (i, m)
+    calls = "\n".join(["{0:3d}.  {1!s}".format(i, m)
                        for i, m in enumerate(self._expected_methods)])
-    return "Verify: Expected methods never called:\n%s" % (calls,)
+    return "Verify: Expected methods never called:\n{0!s}".format(calls)
 
 
 class UnexpectedMethodCallError(Error):
@@ -123,8 +123,7 @@ class UnexpectedMethodCallError(Error):
     self._expected = expected
 
   def __str__(self):
-    return "Unexpected method call: %s.  Expecting: %s" % \
-      (self._unexpected_method, self._expected)
+    return "Unexpected method call: {0!s}.  Expecting: {1!s}".format(self._unexpected_method, self._expected)
 
 
 class UnknownMethodCallError(Error):
@@ -143,8 +142,8 @@ class UnknownMethodCallError(Error):
     self._unknown_method_name = unknown_method_name
 
   def __str__(self):
-    return "Method called is not a member of the object: %s" % \
-      self._unknown_method_name
+    return "Method called is not a member of the object: {0!s}".format( \
+      self._unknown_method_name)
 
 
 class Mox(object):
@@ -615,8 +614,8 @@ class MockMethod(object):
   def __str__(self):
     params = ', '.join(
         [repr(p) for p in self._params or []] +
-        ['%s=%r' % x for x in sorted((self._named_params or {}).items())])
-    desc = "%s(%s) -> %r" % (self._name, params, self._return_value)
+        ['{0!s}={1!r}'.format(*x) for x in sorted((self._named_params or {}).items())])
+    desc = "{0!s}({1!s}) -> {2!r}".format(self._name, params, self._return_value)
     return desc
 
   def __eq__(self, rhs):
@@ -898,7 +897,7 @@ class StrContains(Comparator):
       return False
 
   def __repr__(self):
-    return '<str containing \'%s\'>' % self._search_string
+    return '<str containing \'{0!s}\'>'.format(self._search_string)
 
 
 class Regex(Comparator):
@@ -929,9 +928,9 @@ class Regex(Comparator):
     return self.regex.search(rhs) is not None
 
   def __repr__(self):
-    s = '<regular expression \'%s\'' % self.regex.pattern
+    s = '<regular expression \'{0!s}\''.format(self.regex.pattern)
     if self.regex.flags:
-      s += ', flags=%d' % self.regex.flags
+      s += ', flags={0:d}'.format(self.regex.flags)
     s += '>'
     return s
 
@@ -965,7 +964,7 @@ class In(Comparator):
     return self._key in rhs
 
   def __repr__(self):
-    return '<sequence or map containing \'%s\'>' % self._key
+    return '<sequence or map containing \'{0!s}\'>'.format(self._key)
 
 
 class ContainsKeyValue(Comparator):
@@ -999,7 +998,7 @@ class ContainsKeyValue(Comparator):
       return False
 
   def __repr__(self):
-    return '<map containing the entry \'%s: %s\'>' % (self._key, self._value)
+    return '<map containing the entry \'{0!s}: {1!s}\'>'.format(self._key, self._value)
 
 
 class SameElementsAs(Comparator):
@@ -1040,7 +1039,7 @@ class SameElementsAs(Comparator):
     return expected == actual
 
   def __repr__(self):
-    return '<sequence with same elements as \'%s\'>' % self._expected_seq
+    return '<sequence with same elements as \'{0!s}\'>'.format(self._expected_seq)
 
 
 class And(Comparator):
@@ -1073,7 +1072,7 @@ class And(Comparator):
     return True
 
   def __repr__(self):
-    return '<AND %s>' % str(self._comparators)
+    return '<AND {0!s}>'.format(str(self._comparators))
 
 
 class Or(Comparator):
@@ -1106,7 +1105,7 @@ class Or(Comparator):
     return False
 
   def __repr__(self):
-    return '<OR %s>' % str(self._comparators)
+    return '<OR {0!s}>'.format(str(self._comparators))
 
 
 class Func(Comparator):
@@ -1189,7 +1188,7 @@ class MethodGroup(object):
     return self._group_name
 
   def __str__(self):
-    return '<%s "%s">' % (self.__class__.__name__, self._group_name)
+    return '<{0!s} "{1!s}">'.format(self.__class__.__name__, self._group_name)
 
   def AddMethod(self, mock_method):
     raise NotImplementedError

--- a/python/setup.py
+++ b/python/setup.py
@@ -59,10 +59,10 @@ def generate_proto(source, require = True):
   if (not os.path.exists(output) or
       (os.path.exists(source) and
        os.path.getmtime(source) > os.path.getmtime(output))):
-    print("Generating %s..." % output)
+    print("Generating {0!s}...".format(output))
 
     if not os.path.exists(source):
-      sys.stderr.write("Can't find required file: %s\n" % source)
+      sys.stderr.write("Can't find required file: {0!s}\n".format(source))
       sys.exit(-1)
 
     if protoc is None:
@@ -140,7 +140,7 @@ class build_py(_build_py):
     # Make sure google.protobuf/** are valid packages.
     for path in ['', 'internal/', 'compiler/', 'pyext/', 'util/']:
       try:
-        open('google/protobuf/%s__init__.py' % path, 'a').close()
+        open('google/protobuf/{0!s}__init__.py'.format(path), 'a').close()
       except EnvironmentError:
         pass
     # _build_py is an old-style class, so super() doesn't work.
@@ -153,7 +153,7 @@ class test_conformance(_build_py):
       # Python 2.6 dodges these extra failures.
       os.environ["CONFORMANCE_PYTHON_EXTRA_FAILURES"] = (
           "--failure_list failure_list_python-post26.txt")
-    cmd = 'cd ../conformance && make %s' % (test_conformance.target)
+    cmd = 'cd ../conformance && make {0!s}'.format((test_conformance.target))
     status = subprocess.check_call(cmd, shell=True)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:protobuf?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:protobuf?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
